### PR TITLE
Retry ChannelMessage if processed between channel close and ShutdownSignal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ target
 
 # Mac
 .DS_Store
+
+src/test/resources/application.conf

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object Build extends Build {
     licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     homepage := Some(new URL("https://github.com/thenewmotion/akka-rabbitmq")),
     scalacOptions := Seq("-encoding", "UTF-8", "-unchecked", "-deprecation", "-feature"),
-    libraryDependencies ++= Seq(akkaActor, amqpClient, akkaTestkit, specs2JUnit, specs2Mock))
+    libraryDependencies ++= Seq(akkaActor, amqpClient, akkaTestkit, specs2JUnit, specs2Mock, typesafeConfig))
 
   val akkaVersion = "2.3.7"
 
@@ -20,6 +20,7 @@ object Build extends Build {
   val amqpClient  = "com.rabbitmq" % "amqp-client" % "3.4.2"
   val specs2JUnit = "org.specs2" %% "specs2-junit" % "2.4.15" % "test"
   val specs2Mock  = "org.specs2" %% "specs2-mock" % "2.4.15" % "test"
+  val typesafeConfig = "com.typesafe" % "config" % "1.0.2" % "test"
 
   val root = Project(
     "akka-rabbitmq",

--- a/src/main/scala/com/thenewmotion/akka/rabbitmq/ChannelActor.scala
+++ b/src/main/scala/com/thenewmotion/akka/rabbitmq/ChannelActor.scala
@@ -23,6 +23,10 @@ object ChannelActor {
 
   def props(setupChannel: (Channel, ActorRef) => Any = (_, _) => ()): Props =
     Props(classOf[ChannelActor], setupChannel)
+
+  private[rabbitmq] case class Retrying(retries: Int, onChannel: OnChannel) extends OnChannel {
+    def apply(channel: Channel) = onChannel(channel)
+  }
 }
 
 class ChannelActor(setupChannel: (Channel, ActorRef) => Any)
@@ -33,14 +37,52 @@ class ChannelActor(setupChannel: (Channel, ActorRef) => Any)
 
   startWith(Disconnected, InMemory())
 
+  private sealed trait ProcessingResult {}
+  private case class ProcessSuccess(m: Any) extends ProcessingResult
+  private case class ProcessFailureRetry(onChannel: Retrying) extends ProcessingResult
+  private case object ProcessFailureDrop extends ProcessingResult
+
+  private def safeWithRetry(channel: Channel, fn: OnChannel): ProcessingResult = {
+    safe(fn(channel)) match {
+      case Some(r) =>
+        ProcessSuccess(r)
+
+      case None if (channel.isOpen()) =>
+        /* if the function failed, BUT the channel is still open, we know that the problem was with f, and not the
+         channel state.
+
+         Therefore we do *not* retry f in this case because its failure might be due to some inherent problem with f
+         itself, and in that case a whole application might get stuck in a retry loop.
+         */
+        ProcessFailureDrop
+
+      case None =>
+        /*
+         The channel is closed, but the actor state believed it was open; There is a small window between a disconnect, sending an AmqpShutdownSignal, and processing that signal
+         Just because our ChannelMessage was processed in this window does not mean we should ignore the intent of dropIfNoChannel (because there was, in fact, no channel)
+         */
+        fn match {
+          case Retrying(retries, _) if retries == 0 =>
+            ProcessFailureDrop
+          case Retrying(retries, onChannel) =>
+            ProcessFailureRetry(Retrying(retries - 1, onChannel))
+          case _ =>
+            ProcessFailureRetry(Retrying(3, fn))
+        }
+    }
+  }
+
   when(Disconnected) {
     case Event(channel: Channel, InMemory(queue)) =>
       setup(channel)
       def loop(xs: List[OnChannel]): State = xs match {
         case Nil => goto(Connected) using Connected(channel)
-        case (h :: t) => safe(h(channel)) match {
-          case Some(_) => loop(t)
-          case None =>
+        case (h :: t) => safeWithRetry(channel, h) match {
+          case ProcessSuccess(_) => loop(t)
+          case ProcessFailureRetry(retry) =>
+            reconnect(channel)
+            stay using InMemory(Queue((retry :: t): _*))
+          case ProcessFailureDrop =>
             reconnect(channel)
             stay using InMemory(Queue(t: _*))
         }
@@ -69,14 +111,15 @@ class ChannelActor(setupChannel: (Channel, ActorRef) => Any)
       reconnect(channel)
       goto(Disconnected) using InMemory()
 
-    case Event(ChannelMessage(f, _), Connected(channel)) =>
-      safe(f(channel)) match {
-        case None =>
-          // Note that we do *not* retry f in this case because its failure might be due to some inherent problem with
-          // f itself, and in that case a whole application might get stuck in a retry loop.
+    case Event(cm @ ChannelMessage(f, _), Connected(channel)) =>
+      safeWithRetry(channel, f) match {
+        case ProcessSuccess(_) => stay()
+        case ProcessFailureRetry(retry) if !cm.dropIfNoChannel =>
           reconnect(channel)
-          goto(Disconnected) using InMemory()
-        case _ => stay()
+          goto(Disconnected) using (InMemory(Queue(retry)))
+        case _ =>
+          reconnect(channel)
+          goto(Disconnected) using (InMemory())
       }
   }
   onTransition {

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+rabbitmq {
+  host = 127.0.0.1
+  port = 5672
+  username = guest
+  password = guest
+}

--- a/src/test/scala/com/thenewmotion/akka/rabbitmq/PublishSubscribeSpec.scala
+++ b/src/test/scala/com/thenewmotion/akka/rabbitmq/PublishSubscribeSpec.scala
@@ -14,6 +14,12 @@ class PublishSubscribeSpec extends ActorSpec {
 
     "Publish and Subscribe" in new TestScope {
       val factory = new ConnectionFactory()
+      val config = com.typesafe.config.ConfigFactory.load().getConfig("rabbitmq")
+      factory.setHost(config.getString("host"))
+      factory.setPort(config.getInt("port"))
+      factory.setUsername(config.getString("username"))
+      factory.setPassword(config.getString("password"))
+
       val connection = system.actorOf(ConnectionActor.props(factory), "rabbitmq")
       val exchange = "amq.fanout"
 


### PR DESCRIPTION
There exists a small window in which a channel could be closed, but the
ChannelActor state indicates otherwise. This makes the "dropIfNoChannel"
flag for ChannelMessage unreliable, as it WILL drop in this case.

Since it's possible that the ChannelMessage is responsible for breaking
and closing the channel, we don't want to retry it forever, so a limited
retry mechanism is introduced. 4 failures in a row with a successful
reconnect between each is a good indication of a problematic
ChannelMessage, after which point the ChannelMessage will be dropped.

If dropIfNoChannel == true, then retry mechanism is not invoked.