### PR TITLE
Bump Akka to 2.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licen
 homepage := Some(new URL("https://github.com/thenewmotion/akka-rabbitmq"))
 
 libraryDependencies ++= {
-  val akkaVersion = "2.3.12"
+  val akkaVersion = "2.4.0"
 
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,


### PR DESCRIPTION
Just a version bump on Akka.  I'm getting some eviction errors because I'm using 2.4.0 and akka-rabbit is using the previous version.  Akka has deprecated a few things in 2.4.0 but they old calls still work so I just left them alone here.