### PR TITLE
Allow connection state to be queried

### DIFF
--- a/src/test/scala/com/thenewmotion/akka/rabbitmq/ChannelActorSpec.scala
+++ b/src/test/scala/com/thenewmotion/akka/rabbitmq/ChannelActorSpec.scala
@@ -104,6 +104,13 @@ class ChannelActorSpec extends ActorSpec with Mockito {
       there was one(onChannel).apply(channel)
       state mustEqual disconnected(last)
     }
+    "respond to GetState message" in new TestScope {
+      actorRef ! GetState
+      expectMsg(Disconnected)
+      actorRef.setState(Connected, Connected(channel))
+      actorRef ! GetState
+      expectMsg(Connected)
+    }
   }
 
   private abstract class TestScope extends ActorScope {


### PR DESCRIPTION
Made ChannelActor state public so SubscribeTransitionCallBack can be used.  
Also added GetState message to query the current state.