### PR TITLE
Re-enabled Scala 2.10/2.11 cross build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The main idea implemented in library is to survive losing connection with Rabbit
 
 It gives you two actors `ConnectionActor` and `ChannelActor`
 
+The Scala 2.10 version uses Akka 2.3.14, while the Scala 2.11 version uses Akka 2.4.1
+
 ### ConnectionActor
 * handles connection failures and notifies children
 * keep trying to reconnect if connection lost
@@ -27,7 +29,7 @@ using confirms is included as `ConfirmsExample.scala`.
 
 ``` scala
 resolvers += "The New Motion Public Repo" at "http://nexus.thenewmotion.com/content/groups/public/"
-libraryDependencies += "com.thenewmotion.akka" %% "akka-rabbitmq" % "1.2.4"
+libraryDependencies += "com.thenewmotion.akka" %% "akka-rabbitmq" % "2.2"
 ```
 
 ### Maven
@@ -42,8 +44,7 @@ libraryDependencies += "com.thenewmotion.akka" %% "akka-rabbitmq" % "1.2.4"
 <dependency>
     <groupId>com.thenewmotion.akka</groupId>
     <artifactId>akka-rabbitmq_{2.10/2.11}</artifactId>
-    <!-- use version 2.0 for Akka 2.4.x, or 1.2.7 for Akka 2.3.x -->
-    <version>2.0</version>
+    <version>2.2</version>
 </dependency>
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,33 @@
-import tnm.ScalaVersion
-
 organization := "com.thenewmotion.akka"
 name := "akka-rabbitmq"
 
 enablePlugins(OssLibPlugin)
 
-crossScalaVersions := Seq(ScalaVersion.curr)
-
 licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0")))
 homepage := Some(new URL("https://github.com/thenewmotion/akka-rabbitmq"))
 
+def akka(scalaVersion: String) = {
+  val version = scalaVersion match {
+    case x if x.startsWith("2.10") => "2.3.14"
+    case x => "2.4.1"
+  }
+
+  def libs(xs: String*) = xs.map(x => "com.typesafe.akka" %% s"akka-$x" % version)
+
+  libs("actor") ++ libs("testkit").map(_ % "test")
+}
+
 libraryDependencies ++= {
-  val akkaVersion = "2.4.0"
-
   Seq(
-    "com.typesafe.akka" %% "akka-actor" % akkaVersion,
     "com.rabbitmq" % "amqp-client" % "3.4.2",
-
-    "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
     "com.typesafe" % "config" % "1.0.2" % "test",
     "org.specs2" %% "specs2-mock" % "2.4.17" % "test"
   )
+}
+libraryDependencies <++= scalaVersion { v: String => akka(v) }
+
+unmanagedSourceDirectories in Compile <+= (sourceDirectory in Compile, scalaBinaryVersion){
+  (s, v) => s / ("scala_"+v)
 }
 
 Format.settings

--- a/src/main/scala/com/thenewmotion/akka/rabbitmq/examples/ConfirmsExample.scala
+++ b/src/main/scala/com/thenewmotion/akka/rabbitmq/examples/ConfirmsExample.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
  * successfully delivered to RabbitMQ. See https://www.rabbitmq.com/confirms.html for more information on publisher
  * confirms.
  */
-object ConfirmsExample extends App {
+object ConfirmsExample extends App with ActorSystemTerminator {
 
   /* --- Some things shared by publisher and consumer --- */
 
@@ -100,7 +100,7 @@ object ConfirmsExample extends App {
   /* --- Letting the app run --- */
 
   Thread.sleep(7000)
-  Await.result(system.terminate(), 1.second)
+  Await.result(terminateActorSystem(system), 1.second)
 
   System.out.println(s"Unconfirmed messages: ${unconfirmed.mkString(", ")}")
 }

--- a/src/main/scala/com/thenewmotion/akka/rabbitmq/examples/TutorialInComparisons.scala
+++ b/src/main/scala/com/thenewmotion/akka/rabbitmq/examples/TutorialInComparisons.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 /**
  * @author Yaroslav Klymko
  */
-class TutorialInComparisons(implicit system: ActorSystem) {
+class TutorialInComparisons(implicit system: ActorSystem) extends ActorSystemTerminator {
 
   val connection = {
     val factory = new ConnectionFactory()
@@ -79,6 +79,6 @@ class TutorialInComparisons(implicit system: ActorSystem) {
   Await.result({
     system stop channelActor
     system stop connectionActor // will close all channels associated with this connections
-    system.terminate()
+    terminateActorSystem(system)
   }, 5.seconds)
 }

--- a/src/main/scala_2.10/com.thenewmotion.akka.rabbitmq.examples/ActorSystemTerminator.scala
+++ b/src/main/scala_2.10/com.thenewmotion.akka.rabbitmq.examples/ActorSystemTerminator.scala
@@ -1,0 +1,8 @@
+package com.thenewmotion.akka.rabbitmq.examples
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+
+trait ActorSystemTerminator {
+  def terminateActorSystem(actorSystem: ActorSystem): Future[Unit] = Future.successful(actorSystem.shutdown())
+}

--- a/src/main/scala_2.11/com.thenewmotion.akka.rabbitmq/examples/ActorSystemTerminator.scala
+++ b/src/main/scala_2.11/com.thenewmotion.akka.rabbitmq/examples/ActorSystemTerminator.scala
@@ -1,0 +1,9 @@
+package com.thenewmotion.akka.rabbitmq.examples
+
+import akka.actor.{Terminated, ActorSystem}
+
+import scala.concurrent.Future
+
+trait ActorSystemTerminator {
+  def terminateActorSystem(actorSystem: ActorSystem): Future[Terminated] = actorSystem.terminate()
+}


### PR DESCRIPTION
Re-enabled a cross build for Scala 2.10 w/ Akka 2.3.14 & Scala 2.11 w/ Akka 2.4.1, as we are not using any specific new features from Akka 2.4