### PR TITLE
fix for https://github.com/thenewmotion/akka-rabbitmq/issues/27

### DIFF
--- a/src/main/scala/com/thenewmotion/akka/rabbitmq/ConnectionActor.scala
+++ b/src/main/scala/com/thenewmotion/akka/rabbitmq/ConnectionActor.scala
@@ -23,7 +23,7 @@ object ConnectionActor {
 
   def props(
     factory: ConnectionFactory,
-    reconnectionDelay: FiniteDuration = 10.seconds,
+    reconnectionDelay: FiniteDuration = 3.seconds,
     setupConnection: (Connection, ActorRef) => Any = (_, _) => ()): Props =
     Props(classOf[ConnectionActor], factory, reconnectionDelay, setupConnection)
 }
@@ -124,7 +124,7 @@ class ConnectionActor(
     log.debug("{} closing broken connection {}", self.path, connection)
     closeIfOpen(connection)
 
-    self ! Connect
+    setTimer(reconnectTimer, Connect, reconnectionDelay / 3, repeat = false)
     children.foreach(_ ! ParentShutdownSignal)
   }
 

--- a/src/main/scala/com/thenewmotion/akka/rabbitmq/ConnectionActor.scala
+++ b/src/main/scala/com/thenewmotion/akka/rabbitmq/ConnectionActor.scala
@@ -23,7 +23,7 @@ object ConnectionActor {
 
   def props(
     factory: ConnectionFactory,
-    reconnectionDelay: FiniteDuration = 3.seconds,
+    reconnectionDelay: FiniteDuration = 10.seconds,
     setupConnection: (Connection, ActorRef) => Any = (_, _) => ()): Props =
     Props(classOf[ConnectionActor], factory, reconnectionDelay, setupConnection)
 }
@@ -124,7 +124,7 @@ class ConnectionActor(
     log.debug("{} closing broken connection {}", self.path, connection)
     closeIfOpen(connection)
 
-    setTimer(reconnectTimer, Connect, reconnectionDelay / 3, repeat = false)
+    setTimer(reconnectTimer, Connect, 1.seconds, repeat = false)
     children.foreach(_ ! ParentShutdownSignal)
   }
 

--- a/src/test/scala/com/thenewmotion/akka/rabbitmq/ConnectionActorSpec.scala
+++ b/src/test/scala/com/thenewmotion/akka/rabbitmq/ConnectionActorSpec.scala
@@ -57,6 +57,8 @@ class ConnectionActorSpec extends ActorSpec with Mockito with NoTimeConversions 
     "reconnect on ShutdownSignalException from server" in new TestScope {
       actorRef.setState(Connected, Connected(initialConnection))
       actor.shutdownCompleted(shutdownSignal())
+      expectMsg(ParentShutdownSignal)
+      expectMsg(10 seconds, channel)
       state mustEqual connectedAfterRecovery
     }
 
@@ -129,8 +131,9 @@ class ConnectionActorSpec extends ActorSpec with Mockito with NoTimeConversions 
 
       // give connection actor the time to close and reconnect
       expectMsg(ParentShutdownSignal)
+      Thread.sleep(3000)
       there was one(initialConnection).close()
-      expectMsg(channel)
+      expectMsg(10 seconds, channel)
 
       // now because of this close, RabbitMQ may tell the actor that the previous connection was shut down by the app
       actor.shutdownCompleted(shutdownSignal(initiatedByApplication = true, reference = initialConnection))


### PR DESCRIPTION
Add a delay for connection recovery. Which will cause connectionActor handle `ProvideChannel` message is `Disconnected` State. After the connection recovered, then send fresh channels to it's children.
